### PR TITLE
Add sample Hello World VS Code extension

### DIFF
--- a/hello-world-extension/README.md
+++ b/hello-world-extension/README.md
@@ -1,0 +1,11 @@
+# Hello World Extension
+
+This is a minimal sample Visual Studio Code extension created manually.
+
+It registers a single command `helloWorldExtension.helloWorld` that shows a `Hello World` message when executed.
+
+## Usage
+
+1. Run `npm install`.
+2. Press `F5` in VS Code to start the extension in the Extension Development Host.
+3. Execute the `Hello World` command from the Command Palette.

--- a/hello-world-extension/package-lock.json
+++ b/hello-world-extension/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "hello-world-extension",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hello-world-extension",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^18",
+        "@types/vscode": "^1.54.0",
+        "typescript": "^4.0.0"
+      },
+      "engines": {
+        "vscode": "^1.54.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.111",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
+      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
+      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/hello-world-extension/package.json
+++ b/hello-world-extension/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "hello-world-extension",
+  "displayName": "Hello World Extension",
+  "description": "Sample Hello World VS Code extension",
+  "version": "0.0.1",
+  "publisher": "sample",
+  "engines": {
+    "vscode": "^1.54.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:helloWorldExtension.helloWorld"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "helloWorldExtension.helloWorld",
+        "title": "Hello World"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "@types/vscode": "^1.54.0",
+    "typescript": "^4.0.0"
+  }
+}

--- a/hello-world-extension/src/extension.ts
+++ b/hello-world-extension/src/extension.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('helloWorldExtension.helloWorld', () => {
+    vscode.window.showInformationMessage('Hello World from your extension!');
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/hello-world-extension/tsconfig.json
+++ b/hello-world-extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a minimal Hello World VS Code extension in `hello-world-extension`

## Testing
- `npm install --silent` and `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_6843a930e4688328a0995c2afef87e6d